### PR TITLE
Removed `uglifyjs-webpack-plugin`

### DIFF
--- a/conf/package.json
+++ b/conf/package.json
@@ -30,7 +30,6 @@
     "tslint": "^5.9.1",
     "tslint-loader": "^3.6.0",
     "typescript": "^2.7.2",
-    "uglifyjs-webpack-plugin": "^1.2.2",
     "webpack": "^4.1.0",
     "webpack-cli": "^2.0.10",
     "webpack-dev-server": "^3.1.0",

--- a/conf/webpack.prod.conf.js
+++ b/conf/webpack.prod.conf.js
@@ -2,7 +2,6 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 
 const transpile = process.env.TRANSPILE === 'true';
@@ -11,7 +10,7 @@ module.exports = {
   entry: {
     app: '../src/bootstrap'
   },
-  mode: 'development', // TODO: Fix build not working when mode = production
+  mode: 'production',
   output: {
     filename: 'scripts/[name].js',
     chunkFilename: 'scripts/[name].js',
@@ -111,7 +110,6 @@ module.exports = {
   },
   plugins: [
     new CleanWebpackPlugin(['build'], {root: path.resolve(__dirname, '..')}),
-    new UglifyJSPlugin(),
     new HtmlWebpackPlugin({
       minify: {
         collapseWhitespace: true,


### PR DESCRIPTION
When mode is set to production, webpack 4 will automatically uglify its output, so the UglifyJS plugin became useless. Without it, the production mode works flawlessly