### PR TITLE
Added an easy way to change the PWA base path

### DIFF
--- a/conf/webpack.dev.conf.js
+++ b/conf/webpack.dev.conf.js
@@ -64,6 +64,7 @@ module.exports = {
   plugins: [
     new CleanWebpackPlugin(['dev'], {verbose: true, root: path.resolve(__dirname, '..')}),
     new HtmlWebpackPlugin({
+      basePath: '/',
       hash: true,
       inject: true,
       template: '!!handlebars-loader!../src/index.hbs',

--- a/conf/webpack.prod.conf.js
+++ b/conf/webpack.prod.conf.js
@@ -124,6 +124,7 @@ module.exports = {
     new CleanWebpackPlugin(['build'], {root: path.resolve(__dirname, '..')}),
     new HtmlWebpackPlugin({
       transpile,
+      basePath: process.env.BASE_PATH || '/',
       minify: {
         collapseWhitespace: true,
         removeComments: true,

--- a/src/index.hbs
+++ b/src/index.hbs
@@ -8,7 +8,7 @@
     <title>My App</title>
     <meta name="description" content="My App description">
 
-    <base href="/">
+    <base href="{{htmlWebpackPlugin.options.basePath}}">
 
     <link rel="icon" href="images/favicon.ico">
 
@@ -40,7 +40,7 @@
     <meta name="msapplication-tap-highlight" content="no">
 
     <script>
-      window.Polymer = {rootPath: '/'};
+      window.Polymer = {rootPath: '{{htmlWebpackPlugin.options.basePath}}'};
       // Load and register pre-caching Service Worker
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', function () {


### PR DESCRIPTION
Now webpack will use the BASE_PATH environment variable to set the base path of the PWA. If omitted, `/` will be used by default